### PR TITLE
Fixbug- error when key is not in rfc2 dictionary

### DIFF
--- a/pyfiscal/generate.py
+++ b/pyfiscal/generate.py
@@ -75,7 +75,10 @@ class GenerateRFC(BaseGenerator):
 		div = (div-mod)/34
 		homoclave = ''
 		homoclave += self.rfc_set(rfc2[int(div)], 'Z')
-		homoclave += self.rfc_set(rfc2[int(mod)], 'Z')
+		if rfc2.get(int(mod)):
+			homoclave += self.rfc_set(rfc2[int(mod)], 'Z')
+		else:
+			homoclave += self.rfc_set(rfc2[0], 'Z')
 		return homoclave
 
 	def verification_number(self, rfc):


### PR DESCRIPTION
For some names like "ARAGON MURO JONAS"
or "GALARZA NAVA SANTIAGO", an error is generated when the value is not found within the rfc2 dictionary.
This is not the definitive solution since it only assigns the value of "1" when the error occurs, it is an attempt to solve it temporarily since I do not know the rules that apply when creating the RFC