### PR TITLE
Fix residuo conditions

### DIFF
--- a/pyfiscal/generate.py
+++ b/pyfiscal/generate.py
@@ -105,12 +105,13 @@ class GenerateRFC(BaseGenerator):
 			digito = '0'
 			return digito
 
-		if residuo == 10:
-			digito = 'A'
-			return digito
-
 		if residuo > 0:
 			digito = str((11 - residuo))
+
+			if digito == '10':
+				digito = 'A'
+				return digito
+
 			return digito
 
 		return digito

--- a/pyfiscal/generate.py
+++ b/pyfiscal/generate.py
@@ -103,12 +103,17 @@ class GenerateRFC(BaseGenerator):
 
 		if residuo == 0:
 			digito = '0'
-		elif residuo > 0:
-			digito = str((11-residuo))
-		elif residuo == 10:
-			digito = 'A'
+			return digito
 
-		return  digito
+		if residuo == 10:
+			digito = 'A'
+			return digito
+
+		if residuo > 0:
+			digito = str((11 - residuo))
+			return digito
+
+		return digito
 
 
 	@property


### PR DESCRIPTION
This is a fix for unhandled rfc's like: `TAAD9012157910` this had to be calculated `TAAD90121579A`